### PR TITLE
configure.ac : AC_SUBST the reevaluated tokens

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1077,6 +1077,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 CONFPATH=${conftemp}
 AC_DEFINE_UNQUOTED(CONFPATH, "${conftemp}", [Default path for configuration files])
+AC_SUBST(CONFPATH)
 
 dnl same for datadir
 conftemp="${datadir}"
@@ -1084,6 +1085,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 DATADIR=${conftemp}
 AC_DEFINE_UNQUOTED(DATADIR, "${conftemp}", [Default path for data files])
+AC_SUBST(DATADIR)
 
 dnl same for bindir
 conftemp="${bindir}"
@@ -1091,6 +1093,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 BINDIR=${conftemp}
 AC_DEFINE_UNQUOTED(BINDIR, "${conftemp}", [Default path for user executables])
+AC_SUBST(BINDIR)
 
 dnl same for sbindir
 conftemp="${sbindir}"
@@ -1098,6 +1101,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 SBINDIR=${conftemp}
 AC_DEFINE_UNQUOTED(SBINDIR, "${conftemp}", [Default path for system executables])
+AC_SUBST(SBINDIR)
 
 dnl same for libdir
 conftemp="${libdir}"
@@ -1105,6 +1109,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 LIBDIR=${conftemp}
 AC_DEFINE_UNQUOTED(LIBDIR, "${conftemp}", [Default path for system libraries])
+AC_SUBST(LIBDIR)
 
 dnl same for libexecdir
 conftemp="${libexecdir}"
@@ -1112,6 +1117,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 LIBEXECDIR=${conftemp}
 AC_DEFINE_UNQUOTED(LIBEXECDIR, "${conftemp}", [Default path for system libraries - executable helpers])
+AC_SUBST(LIBEXECDIR)
 
 dnl same for prefix
 conftemp="${prefix}"
@@ -1119,6 +1125,7 @@ eval conftemp=\"${conftemp}\"
 eval conftemp=\"${conftemp}\"
 PREFIXDIR=${conftemp}
 AC_DEFINE_UNQUOTED(PREFIXDIR, "${conftemp}", [Default root path for component])
+AC_SUBST(PREFIXDIR)
 
 
 AC_OUTPUT


### PR DESCRIPTION
The `@LIBEXECDIR@` from previous PR did not get expanded; hopefully this would fix it.