### PR TITLE
Problem: obs interprets commented lines incorrectly if blank spaces p…

### DIFF
--- a/packaging/debian/fty-warranty.install
+++ b/packaging/debian/fty-warranty.install
@@ -1,7 +1,7 @@
- ### Note: this file was customized for paths
- usr/libexec/biostimer-warranty-metric
- ###usr/bin/biostimer-warranty-metric
- etc/fty-warranty/biostimer-warranty-metric.cfg
- lib/systemd/system/biostimer-warranty-metric.service
- lib/systemd/system/biostimer-warranty-metric.timer
- ###/usr/lib/systemd/system/biostimer-warranty-metric.timer
+### Note: this file was customized for paths
+usr/libexec/biostimer-warranty-metric
+###usr/bin/biostimer-warranty-metric
+etc/fty-warranty/biostimer-warranty-metric.cfg
+lib/systemd/system/biostimer-warranty-metric.service
+lib/systemd/system/biostimer-warranty-metric.timer
+###/usr/lib/systemd/system/biostimer-warranty-metric.timer


### PR DESCRIPTION
…resent

Solution: blank spaces removed

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>