### PR TITLE
Fix packaging after fty-shm

### DIFF
--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -21,7 +21,7 @@ git clone --quiet --depth 1 -b master https://github.com/42ity/fty-proto.git fty
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common.git fty-common
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-db.git fty-common-db
 git clone --quiet --depth 1 -b master https://github.com/42ity/fty-common-mlm.git fty-common-mlm
-git clone --quiet --depth 1 https://github.com/42ity/fty-shm.git fty_shm
+git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty_shm
 cd -
 
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list zproject >/dev/null 2>&1) || \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -596,7 +596,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'fty_shm' from Git repository..." >&2
         cd ./tmp-deps
-        $CI_TIME git clone --quiet --depth 1-b master  https://github.com/42ity/fty-shm.git fty_shm
+        $CI_TIME git clone --quiet --depth 1 -b master https://github.com/42ity/fty-shm.git fty_shm
         cd ./fty_shm
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -596,7 +596,7 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'fty_shm' from Git repository..." >&2
         cd ./tmp-deps
-        $CI_TIME git clone --quiet --depth 1 https://github.com/42ity/fty-shm.git fty_shm
+        $CI_TIME git clone --quiet --depth 1-b master  https://github.com/42ity/fty-shm.git fty_shm
         cd ./fty_shm
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR

--- a/packaging/debian/fty-warranty.install
+++ b/packaging/debian/fty-warranty.install
@@ -1,5 +1,7 @@
-usr/bin/biostimer-warranty-metric
+### Note: this file was customized for paths
+usr/libexec/biostimer-warranty-metric
+###usr/bin/biostimer-warranty-metric
 etc/fty-warranty/biostimer-warranty-metric.cfg
 lib/systemd/system/biostimer-warranty-metric.service
-/usr/lib/systemd/system/biostimer-warranty-metric.timer
-
+lib/systemd/system/biostimer-warranty-metric.timer
+###/usr/lib/systemd/system/biostimer-warranty-metric.timer

--- a/packaging/redhat/fty-warranty.spec
+++ b/packaging/redhat/fty-warranty.spec
@@ -1,5 +1,6 @@
 #
 #    fty-warranty - Agent sending metrics about warranty expiration
+# NOTE: This file was customized after generation, be sure to keep it
 #
 #    Copyright (C) 2014 - 2018 Eaton
 #
@@ -133,7 +134,9 @@ find %{buildroot} -name '*.la' | xargs rm -f
 
 %files
 %defattr(-,root,root)
-%{_bindir}/biostimer-warranty-metric
+# Note: legacy-dependency override of binary's path
+###%{_bindir}/biostimer-warranty-metric
+%{_libexecdir}/biostimer-warranty-metric
 %{_mandir}/man1/biostimer-warranty-metric*
 %config(noreplace) %{_sysconfdir}/fty-warranty/biostimer-warranty-metric.cfg
 %{SYSTEMD_UNIT_DIR}/biostimer-warranty-metric.service

--- a/project.xml
+++ b/project.xml
@@ -243,8 +243,12 @@
         </use>
     </use>
 
-    <use project = "fty_shm" libname = "libfty_shm" header="fty_shm.h" min_major = "1" test = "fty_shm_test" 
-	repository = "https://github.com/42ity/fty-shm.git"/>
+    <use project = "fty_shm" libname = "libfty_shm" header="fty_shm.h"
+        min_major = "1"
+        test = "fty_shm_test"
+        repository = "https://github.com/42ity/fty-shm.git"
+        release = "master"
+        />
 
     <!-- Note: the added fty-warranty class is currently a dummy
          to satisfy zproject expectations, but later the logic


### PR DESCRIPTION
See also #22 and #10 for related issues, and https://github.com/zeromq/zproject/pull/1161 for a recent fix for timer units path.