### PR TITLE
project.xml / ci_build.sh : clarify the fty-shm dependencies tag…

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -615,7 +615,10 @@ default|default-Werror|default-with-docs|valgrind|clang-format-check)
             $CI_TIME autoconf || \
             $CI_TIME autoreconf -fiv
         fi
-        $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        ( # Custom additional options for fty_shm
+            CONFIG_OPTS+=("--enable-gcc-std-regex=no")
+            $CI_TIME ./configure "${CONFIG_OPTS[@]}"
+        )
         $CI_TIME make -j4
         $CI_TIME make install
         cd "${BASE_PWD}"

--- a/configure.ac
+++ b/configure.ac
@@ -1622,7 +1622,16 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
 # One of big missing features in gcc-4.8 was std::regex support fixed in 4.9
 # Testing code from https://stackoverflow.com/a/41186162/4715872
 # caveats apply (use of unguaranteed private macros)
+AC_ARG_ENABLE([gcc-std-regex],
+    AS_HELP_STRING([--enable-gcc-std-regex],
+        [Check for std::regex support if compiler is GCC, assuming it means satisfactory level of C++11 there [default=yes]]),
+    [enable_gcc_std_regex=$enableval],
+    [enable_gcc_std_regex=$defaultval])
+
+AM_CONDITIONAL([ENABLE_GCC_STD_REGEX], [test x$enable_gcc_std_regex != xno])
+
 AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+  [AS_IF([test "x$enable_gcc_std_regex" = "xyes" || test "x$enable_gcc_std_regex" = "xauto"],
     [AC_MSG_CHECKING([for GNU C++11 support level expected by gcc-4.9 release or newer])
      CXXFLAGS="$CXXFLAGS --std=c++11"
      AC_LANG_PUSH([C++])
@@ -1653,9 +1662,12 @@ int main() {
 #endif
   return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
+     ], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
      AC_LANG_POP([C++])
     ]
+  ,[AC_MSG_WARN([Not checking for GNU C++11 support level expected by gcc-4.9 release or newer, due to explicit configure option])
+    AC_MSG_WARN([YOU ARE AT RISK OF SOMETHING NOT WORKING WITH THIS BUILD OF THE CODEBASE])]
+  )]
 )])
 
 # Optional project-local hook to (re-)define some variables that can be used

--- a/project.xml
+++ b/project.xml
@@ -251,8 +251,53 @@
         min_major = "1"
         test = "fty_shm_test"
         repository = "https://github.com/42ity/fty-shm.git"
-        release = "master"
-        />
+        release = "master">
+
+        <!-- Travis CI unit-tests of current project do not require
+             gcc-4.9 to be installed in the building VM just for
+             this unpackaged dependency to build: -->
+        <add_config_opts>--enable-gcc-std-regex=no</add_config_opts>
+
+        <use project = "fty-proto" libname = "libfty_proto" header = "ftyproto.h" prefix = "fty_proto"
+            min_major = "1" min_minor = "0" min_patch = "0"
+            repository = "https://github.com/42ity/fty-proto.git"
+            release = "master"
+            test = "fty_proto_test" >
+
+            <use project = "czmq"
+                repository = "https://github.com/42ity/czmq.git"
+                release = "v3.0.2-FTY-master"
+                min_major = "3" min_minor = "0" min_patch = "2" >
+
+                <use project = "libzmq"
+                    repository = "https://github.com/42ity/libzmq.git"
+                    release = "4.2.0-FTY-master" >
+
+                    <use project = "libsodium" prefix = "sodium"
+                        repository = "https://github.com/42ity/libsodium.git"
+                        release = "1.0.5-FTY-master"
+                        test = "sodium_init"
+                        />
+                </use>
+            </use>
+
+            <use project = "malamute" min_major = "1" test = "mlm_server_test"
+                repository = "https://github.com/42ity/malamute.git"
+                release = "1.0-FTY-master"
+                />
+
+            <use project = "fty-common-logging" libname = "libfty_common_logging" header = "fty_log.h"
+                repository = "https://github.com/42ity/fty-common-logging.git"
+                release = "master"
+                test = "fty_common_logging_selftest" >
+
+                <use project = "log4cplus" header = "log4cplus/logger.h" test = "appender_test"
+                    repository = "https://github.com/42ity/log4cplus.git"
+                    release = "1.1.2-FTY-master"
+                    />
+            </use>
+        </use>
+    </use>
 
     <!-- Note: the added fty-warranty class is currently a dummy
          to satisfy zproject expectations, but later the logic

--- a/project.xml
+++ b/project.xml
@@ -38,7 +38,7 @@
     <include filename = "license.xml" />
     <version major = "1" minor = "0" patch = "0" />
     <abi current = "1" revision = "0" age = "0" />
-    
+
     <classfilename use-cxx-gcc-4-9 = "true"/> 
 
     <use project = "czmq"


### PR DESCRIPTION
…and do not require g++-4.9 just for it to be used in CI build

For the optional compilation with gcc-4.9 of fty-shm, see https://github.com/42ity/fty-shm/pull/29 and results (green) of custom-branch testing in https://travis-ci.org/jimklimov/fty-warranty/builds/548607184